### PR TITLE
Bug in view() method with integer value as $key and in constructor with NULL $options

### DIFF
--- a/Phly_Couch/library/Phly/Couch.php
+++ b/Phly_Couch/library/Phly/Couch.php
@@ -408,6 +408,7 @@ class Phly_Couch
                 throw new Phly_Couch_Exception('Document updates require a document id; none provided');
             }
             $method = 'PUT';
+            $path  .= $id;
         }
         $this->getHttpClient()->setRawData($document->toJson());
         $response = $this->_prepareAndSend($path, $method);

--- a/Phly_Couch/library/Phly/Couch.php
+++ b/Phly_Couch/library/Phly/Couch.php
@@ -512,7 +512,7 @@ class Phly_Couch
         $db = $this->_verifyDb($db);
         $param = '';
         if (!is_null($key)) {
-            if (is_numeric($key)) {
+            if (is_int($key)) {
                 $param = '/?key='.$key;
             } elseif (is_string($key)) {
                 $param = '/?key=%22'.$key.'%22';

--- a/Phly_Couch/library/Phly/Couch/Document.php
+++ b/Phly_Couch/library/Phly/Couch/Document.php
@@ -5,17 +5,19 @@ class Phly_Couch_Document
 
     public function __construct($options = null)
     {
-        if (is_string($options)) {
-            if ('{' == substr($options, 0, 1)) {
-                $this->loadJson($options);
+        if (null !== $options){
+            if (is_string($options)) {
+                if ('{' == substr($options, 0, 1)) {
+                    $this->loadJson($options);
+                } else {
+                    $this->setId($options);
+                }
+            } elseif (is_array($options)) {
+                $this->loadArray($options);
             } else {
-                $this->setId($options);
+                require_once 'Phly/Couch/Exception.php';
+                throw new Phly_Couch_Exception('Invalid options provided to ' . __CLASS__ . 'constructor');
             }
-        } elseif (is_array($options)) {
-            $this->loadArray($options);
-        } else {
-            require_once 'Phly/Couch/Exception.php';
-            throw new Phly_Couch_Exception('Invalid options provided to ' . __CLASS__ . 'constructor');
         }
     }
 


### PR DESCRIPTION
1.In view method, if $key value is a string ( also if it is numeric string ) escape it with %22 , else if $key is an int don't do this ( now if i want send "123" as a string , i can't do )
2. Allow null $options in Phly_Couch_Document constructor ( now $doc = new Phly_Couch_Document throw an exception )
